### PR TITLE
Add shebang

### DIFF
--- a/bin/webvtt2ass.js
+++ b/bin/webvtt2ass.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 "use strict";
 const webvtt2ass = require("..");
 const fs = require("fs");


### PR DESCRIPTION
It's needed to execute without 'node' in front.